### PR TITLE
Safe Identifiers Version 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ authors = ["Naftuli Kay <rfkrocktk@gmail.com>"]
 id3 = "0.1.11"
 lazy_static = "0.2.2"
 regex = "0.1.80"
+unicode-casefold = "0.2.0"
 walkdir = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use] extern crate lazy_static;
 
 extern crate regex;
+extern crate unicode_casefold;
 
 pub mod fsync;


### PR DESCRIPTION
This is only a first move in the right direction. There are a few things wrong:

 - Test case on src/fsync/mod.rs:75 is wrong, should preserve those characters, we should test and see if PhatNoise works with UTF-8.
 - Test case on src/fsync/mod.rs:85 is wrong, tabs should be replaced with a single space for it to make sense.

Special thank-you to @pingveno and @habnabit for help in making things more sane and Rustly.